### PR TITLE
bitbang: Convert command 'G' => 'g'.

### DIFF
--- a/firmware/modes/bitbang/main.c
+++ b/firmware/modes/bitbang/main.c
@@ -135,7 +135,7 @@ static inline void eval_command(char *cmd)
     */
 
     //Set GND pins
-    case 'G':
+    case 'g':
         if (arg_zif()) {
             set_gnd(last_zif);
         }


### PR DESCRIPTION
Somewhere along the lines, the "g" command became the "G" command, which is currently dummied out. The rest of the code assumes "g", so this PR modifies the firmware to fix it.