### PR TITLE
Windows fixes

### DIFF
--- a/py/otl866/bootloader/driver.py
+++ b/py/otl866/bootloader/driver.py
@@ -27,20 +27,22 @@ VIDS_PIDS = [(AE_USB_VENDOR, AE_USB_PRODUCT), (O_USB_VENDOR, O_USB_PRODUCT)]
 def list_devices():
     devices = list()
 
-    for (vid, pid) in VIDS_PIDS:
-        try:
-            devices.extend([
-                UsbDevice(d) for d in usb.core.find(
-                    idVendor=vid,
-                    idProduct=pid,
-                    find_all=True,
-                )
-            ])
-        except usb.core.NoBackendError as caught:
-            if sys.platform != 'win32':
+    # PyUSB may function and be present on Windows, but many calls, including
+    # writes, raise NotImplementedError. Prefer the Windows API wrapper for
+    # the time being.
+    if sys.platform != 'win32':
+        for (vid, pid) in VIDS_PIDS:
+            try:
+                devices.extend([
+                    UsbDevice(d) for d in usb.core.find(
+                        idVendor=vid,
+                        idProduct=pid,
+                        find_all=True,
+                    )
+                ])
+            except usb.core.NoBackendError as caught:
                 raise caught
-
-    if sys.platform == 'win32':
+    else:
         devices.extend(windows.list_devices())
 
     return devices

--- a/py/otl866/bootloader/windows.py
+++ b/py/otl866/bootloader/windows.py
@@ -377,6 +377,7 @@ class WindowsDevice():
 
         in_buffer = create_string_buffer(bytes(data))
         out_buffer = create_string_buffer(4096)
+        bytes_written = c_ulong()
         call_DeviceIoControl(
             self._file,
             TL866_IOCTL_WRITE,
@@ -384,6 +385,6 @@ class WindowsDevice():
             sizeof(in_buffer),
             out_buffer,
             sizeof(out_buffer),
-            None,  # lpBytesReturned
+            bytes_written,
             None  # lpOverlapped
         )


### PR DESCRIPTION
While using `open-tl866` recently, I required the following fixes to reliably use the Python driver (`otl866`) from a `mingw64` Python:

* Provide an unused `bytes_written` parameter to `DeviceIoControl` when doing `TL866_IOCTL_WRITE`. This fixes a segfault on `mingw64` Python.
* Favor direct Windows API calls over `pyusb`, as the Windows version of `pyusb` raises `NotImplementedError` on many things.