### PR TITLE
otl866/cli: Print usage if no arguments.

### DIFF
--- a/py/otl866/cli.py
+++ b/py/otl866/cli.py
@@ -13,4 +13,8 @@ def main():
     otl866.bootloader.cli.build_argparse(subgroup)
 
     args = parser.parse_args()
-    args.func(args)
+
+    if "func" in vars(args):
+        args.func(args)
+    else:
+        parser.print_usage()


### PR DESCRIPTION
Without this fix, invoking the Python driver without any arguments shows an error message, which
basically means "argparse couldn't find args to parse".

```
$ otl866
Traceback (most recent call last):
  File "C:\msys64\mingw64\bin\otl866-script.py", line 11, in <module>
    load_entry_point('otl866', 'console_scripts', 'otl866')()
  File "C:/msys64/home/william/prj/consult/tl866/open-tl866/py\otl866\cli.py", line 17, in main
    if hasattr(args.func):
AttributeError: 'Namespace' object has no attribute 'func'
```

With this PR, I propose making this more ergonomic by printing the usage banner if `otl866` was invoked with no arguments.