### PR TITLE
Fixed gitmodules (Github doesn't support git protocol).

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/ProgHQ/m-stack.git
 [submodule "firmware/external/cmake-microchip"]
 	path = firmware/external/cmake-microchip
-	url = git://github.com/Elemecca/cmake-microchip.git
+	url = https://github.com/Elemecca/cmake-microchip.git


### PR DESCRIPTION
Fixed submodule URL protocol so that `git submodule` commands do not fail.