### PR TITLE
Make latch and IO reading match input format

### DIFF
--- a/firmware/io.c
+++ b/firmware/io.c
@@ -609,14 +609,19 @@ void print_port_bits(const char *prefix, port_bits_t p_bits)
 
 void print_zif_bits(const char *prefix, zif_bits_t zif_val)
 {
-    printf("%s: %02X %02X %02X %02X %02X\r\n", prefix, zif_val[0], zif_val[1],
-           zif_val[2], zif_val[3], zif_val[4]);
+    if (*prefix != '\0') {
+        printf("%s: ", prefix);
+    }
+    printf("%02X%02X%02X%02X%02X\r\n", zif_val[4], zif_val[3],
+           zif_val[2], zif_val[1], zif_val[0]);
 }
 
 void print_latch_bits(const char *prefix, latch_bits_t lb)
 {
-    printf("%s: 0:%02X 1:%02X 2:%02X 3:%02X 4:%02X 5:%02X 6:%02X 7:%02X\r\n",
-           prefix, lb[0], lb[1], lb[2], lb[3], lb[4], lb[5], lb[6], lb[7]);
+    if (*prefix != '\0') {
+        printf("%s: ", prefix);
+    }
+    printf("%02X%02X%02X%02X%02X%02X%02X%02X\r\n", lb[7], lb[6], lb[5], lb[4], lb[3], lb[2], lb[1], lb[0]);
 }
 
 void io_init(void)

--- a/firmware/modes/bitbang/main.c
+++ b/firmware/modes/bitbang/main.c
@@ -180,7 +180,7 @@ static inline void eval_command(char *cmd)
     case 'T': {
         zif_bits_t zif = {0x00};
         dir_read(zif);
-        print_zif_bits("Result", zif);
+        print_zif_bits("", zif);
         break;
     }
 
@@ -195,7 +195,7 @@ static inline void eval_command(char *cmd)
     case 'Z': {
         zif_bits_t zif = {0x00};
         zif_read(zif);
-        print_zif_bits("Result", zif);
+        print_zif_bits("", zif);
         break;
     }
 

--- a/py/otl866/aclient.py
+++ b/py/otl866/aclient.py
@@ -233,15 +233,13 @@ class AClient:
         ZIF output is LSB first
 
          Z
-        Result: 00 00 00 00 00
-        CMD> 
+        0000000000
+        CMD>
         '''
-        hexstr_raw = self.match_line(r"Result: (.*)", res).group(1)
-        hexstr_lsb = hexstr_raw.replace(" ", "")
-        ret = 0
-        for wordi, word in enumerate(binascii.unhexlify(hexstr_lsb)):
-            ret |= word << (wordi * 8)
-        return ret
+        # skip space Z \r \n
+        i = 0
+        while res[i] != '\n': i += 1
+        return int(res[i:], base=16)
 
     def zif_str(self, val):
         '''


### PR DESCRIPTION
This means that reading IO will result in 10 hex digits like so: AABBCCDDEE where the LSB is ZIF 1. Compare this to the old output
'Result: EESSCCBBAA'. Same change applies to latch.