### PR TITLE
tl866 responses once again are prefixed with 'Result: '

### DIFF
--- a/firmware/modes/bitbang/main.c
+++ b/firmware/modes/bitbang/main.c
@@ -180,7 +180,7 @@ static inline void eval_command(char *cmd)
     case 'T': {
         zif_bits_t zif = {0x00};
         dir_read(zif);
-        print_zif_bits("", zif);
+        print_zif_bits("Result", zif);
         break;
     }
 
@@ -195,7 +195,7 @@ static inline void eval_command(char *cmd)
     case 'Z': {
         zif_bits_t zif = {0x00};
         zif_read(zif);
-        print_zif_bits("", zif);
+        print_zif_bits("Result", zif);
         break;
     }
 

--- a/py/otl866/aclient.py
+++ b/py/otl866/aclient.py
@@ -233,13 +233,11 @@ class AClient:
         ZIF output is LSB first
 
          Z
-        0000000000
+        Result: 0000000000
         CMD>
         '''
-        # skip space Z \r \n
-        i = 0
-        while res[i] != '\n': i += 1
-        return int(res[i:], base=16)
+        hexstr = self.match_line(r"Result: ([0-9a-fA-F]{10})", res).group(1)
+        return int(hexstr, base=16)
 
     def zif_str(self, val):
         '''


### PR DESCRIPTION
The removal of 'Result: ' was a premature optimization that does not improve command throughput, but only serves to a create a more fragile and ambiguous protocol. Hence, we reinstate it here.